### PR TITLE
Don't show filter prompt without translations

### DIFF
--- a/dictcc.el
+++ b/dictcc.el
@@ -157,15 +157,13 @@ Emacs does not like my regexps."
 
 (defun dictcc--request (query)
   "Send the request to look up QUERY on dict.cc."
-  (let ((buffer (current-buffer))
-        (response (url-retrieve-synchronously (dictcc--request-url query))))
-    (with-current-buffer response
-      (let ((translations (dictcc--parse-http-response)))
-        (if (null translations)
-            (message "No translations for ’%s’" query)
-          (save-excursion
-            (switch-to-buffer buffer)
-            (dictcc--select-translation query translations)))))))
+  (let ((response (url-retrieve-synchronously (dictcc--request-url query))))
+    (let ((translations
+           (with-current-buffer response
+             (dictcc--parse-http-response))))
+      (if (null translations)
+          (message "No translations for ’%s’" query)
+        (dictcc--select-translation query translations)))))
 
 (defun dictcc--parse-http-response ()
   "Parse the HTTP response into a list of translation pairs."

--- a/dictcc.el
+++ b/dictcc.el
@@ -161,9 +161,11 @@ Emacs does not like my regexps."
         (response (url-retrieve-synchronously (dictcc--request-url query))))
     (with-current-buffer response
       (let ((translations (dictcc--parse-http-response)))
-        (save-excursion
-          (switch-to-buffer buffer)
-          (dictcc--select-translation query translations))))))
+        (if (null translations)
+            (message "No translations for ’%s’" query)
+          (save-excursion
+            (switch-to-buffer buffer)
+            (dictcc--select-translation query translations)))))))
 
 (defun dictcc--parse-http-response ()
   "Parse the HTTP response into a list of translation pairs."


### PR DESCRIPTION
First off, I'd like to say that this little package helped my a lot while writing my masters thesis, so thanks for that!

This PR fixes the behaviour when no translations are found: Don't show the filter prompt, just exit with a message.

I also added a commit to simplify the buffer handling in dictcc--request, but I didn't try to understand the rest of the code and so it's possible that it breaks some assumptions, somewhere. Let me know if I should remove that commit again.