### PR TITLE
dictcc-at-point: Detect if nothing's at point

### DIFF
--- a/dictcc.el
+++ b/dictcc.el
@@ -284,7 +284,9 @@ At the moment they are of the form `<tr id='trXXX'></tr>'."
   (interactive)
   (if (use-region-p)
       (dictcc (filter-buffer-substring (region-beginning) (region-end)))
-    (dictcc (word-at-point))))
+    (let ((query (word-at-point)))
+      (if query (dictcc query)
+        (error "No word at point")))))
 
 (provide 'dictcc)
 ;;; dictcc.el ends here


### PR DESCRIPTION
Instead of just going with `nil` as the query, it now shows a helpful error
message.