### PR TITLE
Require subr-x for `string-join'

### DIFF
--- a/dictcc.el
+++ b/dictcc.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 
 (defgroup dictcc ()
   "Look up translations on dict.cc."


### PR DESCRIPTION
Without subr-x, I get

  dictcc--tag-to-text: Symbol's function definition is void: string-join

when I try `dictcc-at-point'.

`(require 'subr-x)' seems to fix it.

Tested on Emacs 26.1 with dictcc 1.0.2 from ELPA (no ivy nor helm
installed).