### PR TITLE
fix dictcc--parse-http-response not working

### DIFF
--- a/dictcc.el
+++ b/dictcc.el
@@ -191,6 +191,7 @@ Emacs does not like my regexps."
   "Send the request to look up QUERY on dict.cc."
   (let* ((response (url-retrieve-synchronously (dictcc--request-url query)))
          (translations (with-current-buffer response
+                         (goto-char (point-min))
                          (dictcc--parse-http-response))))
     (if translations
         (dictcc--select-translation query translations)


### PR DESCRIPTION
Apparently the behavior of `url-retrieve` has changed in emacs27. When retrieving the response, the position is set to the end of the buffer. Therefore `search-forward` does not find matches. `(goto-char (point-min))` fixes that. I would appreciate a merge!
Best, and thanks for making this very useful package!