### PR TITLE
Add `completing-read` backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ the word at point or the content of an active region.
   Despite the names source and destination, [dictcc](http://dict.cc) actually
   just looks up queries in both languages at once.  This means that it does not
   matter if you specify the attributes as `"de"` and `"fr"` or `"fr"` and
-  `"de"`.
+  `"de"`.  There is, however, a difference between these terms when it comes to
+  which language to insert into the buffer.
 
 - `dictcc-completion-backend`: Which completion backend to use (Default
   `'ivy`). If you have `helm` installed but not `ivy`, it will be set to `'helm`
-  automatically
+  automatically.  If you want to use neither `helm`, nor `ivy`, setting the
+  variable to `completing-read` will make use of Emacs's default completion
+  system.


### PR DESCRIPTION
## Commit Summary

##### Add completing-read backend

This is a new backend utilising the build-in completing-read interface. So far, unlike the helm and ivy variants, one is only able to insert the dictcc-source-lang version of the word.  This may seemingly be solved by using a transient keymap, but that would force us to either

    a) have the user make that decision as the first keypress, or
    b) incorporate all of the keys invoking self-insert-command into the transient map,

neither of which seem like good options.

##### Update README

- Point out the fact that the default action to select a completion candidate (RET) does depend on the difference between source and destination language.
- Document the new completing-read based system.